### PR TITLE
use shallow clone to submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,22 +1,29 @@
 [submodule "riscv-binutils"]
 	path = riscv-binutils
 	url = ../binutils-gdb.git
+	shallow = true
 [submodule "riscv-gcc"]
 	path = riscv-gcc
 	url = ../gcc.git
+	shallow = true
 [submodule "riscv-glibc"]
 	path = riscv-glibc
 	url = ../glibc.git
+	shallow = true
 [submodule "riscv-dejagnu"]
 	path = riscv-dejagnu
 	url = https://github.com/riscv-collab/riscv-dejagnu.git
 	branch = riscv-dejagnu-1.6
+	shallow = true
 [submodule "riscv-newlib"]
 	path = riscv-newlib
 	url = ../newlib.git
+	shallow = true
 [submodule "riscv-gdb"]
 	path = riscv-gdb
 	url = ../binutils-gdb.git
+	shallow = true
 [submodule "qemu"]
 	path = qemu
 	url = ../qemu
+	shallow = true


### PR DESCRIPTION
shallow clone will reduce download size and disk usage.

used in main repository

https://github.com/riscv-collab/riscv-gnu-toolchain/blob/a33dac0251d17a7b74d99bd8fd401bfce87d2aed/.gitmodules#L5C2-L5C16

